### PR TITLE
Remove cover image from blog post entries

### DIFF
--- a/themes/aindustriosa/layout/_partial/article.ejs
+++ b/themes/aindustriosa/layout/_partial/article.ejs
@@ -16,8 +16,6 @@
             <%- partial('post/tag') %>
         </footer>
 
-        <%- image_tag(image_version(post.cover || theme.cover, {prefix: 'header'}), {class: "post-cover"}) %>
-
         <div class="post-content" itemprop="articleBody">
             <%- post.content %>
         </div>


### PR DESCRIPTION
Un dos comentarios recibidos foi que se duplicaba a imaxe que saía nos blogs. O problema é que a imaxe que poñemos en `cover` úsase tanto para a miniatura coma para unha especie de cabeceira. O que fixen foi quitar esta cabeceira das plantillas do blog.

AGORA:
![Captura de pantalla de 2021-03-26 19-47-35](https://user-images.githubusercontent.com/1484796/112679431-74ac6780-8e6c-11eb-8a28-c6a65e0c2150.png)

ANTES:
![Captura de pantalla de 2021-03-26 19-48-04](https://user-images.githubusercontent.com/1484796/112679490-82fa8380-8e6c-11eb-9167-cf21fe6f8e77.png)
