### PR TITLE
Run Github actions daily

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,6 +1,8 @@
 name: Pages
 
 on:
+  schedule:
+    - cron: "* 16 * * *"
   push:
     branches:
       - master  # default branch


### PR DESCRIPTION
Based on what @sergiocarracedo did for Vigotech repo, I'm adding a couple of lines to run GH actions periodically, even when there's no merges to master. This is important because we may have Youtube videos, but the webpage will not be updated and will not show them until we may merge something new to master.